### PR TITLE
[ttv] make banner print correctly

### DIFF
--- a/ttt-ttv/src/main/java/com/skynav/ttv/app/TimedTextVerifier.java
+++ b/ttt-ttv/src/main/java/com/skynav/ttv/app/TimedTextVerifier.java
@@ -2143,9 +2143,9 @@ public class TimedTextVerifier implements VerifierContext {
         OptionProcessor optionProcessor = (OptionProcessor) resultProcessor;
         try {
             List<String> argsPreProcessed = preProcessOptions(args, optionProcessor);
+            List<String> nonOptionArgs = parseArgs(argsPreProcessed, optionProcessor);
             showBanner(getShowOutput(), optionProcessor);
             getShowOutput().flush();
-            List<String> nonOptionArgs = parseArgs(argsPreProcessed, optionProcessor);
             if (showModels)
                 showModels();
             if (showRepository)


### PR DESCRIPTION
I believe it is a bug, that banner message gets printed even if `--quiet` argument is provided. The reason for this is, that arguments get parsed after the banner is already printed.