### PR TITLE
Replace U+2014 by U+2E3A when the "wide" designation is used.

### DIFF
--- a/ttt-cap2tt/src/main/java/com/skynav/cap2tt/converter/imsc/IMSC11ResourceConverterState.java
+++ b/ttt-cap2tt/src/main/java/com/skynav/cap2tt/converter/imsc/IMSC11ResourceConverterState.java
@@ -308,7 +308,7 @@ public class IMSC11ResourceConverterState extends AbstractResourceConverterState
     }
 
     private boolean isHorizontalBar(String text) {
-        return (text.length() == 1) && (text.charAt(0) == '\u2015');
+        return (text.length() == 1) && ((text.charAt(0) == '\u2015') || (text.charAt(0) == '\u2014'));
     }
 
     private Span augmentStyledSpan(Span s, Attribute a) {


### PR DESCRIPTION
The same logic that is applied to U+2015 is proposed here for U+2014. 