### PR TITLE
[ttpe] Add commons-logging depenency.

### DIFF
--- a/ttt-ttpe-all/pom.xml
+++ b/ttt-ttpe-all/pom.xml
@@ -15,6 +15,7 @@
 
   <properties>
     <icu4j.version>54.1.1</icu4j.version>
+    <logging.version>1.0.4</logging.version>
   </properties>
 
   <dependencies>
@@ -54,6 +55,19 @@
       <version>3.0.0</version>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>windows</id>
+      <dependencies>
+        <dependency>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+          <version>${logging.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>

--- a/ttt-ttpe/README.md
+++ b/ttt-ttpe/README.md
@@ -6,6 +6,7 @@ Timed Text Presentation Engine
 
 In order to build **ttpe**, first perform the instructions at https://github.com/skynav/ttt, then run `mvn clean install` from this `ttt-ttpe` directory.
 Next, change directory to the standalone JAR package, ``cd ../ttt-ttpe-all``, then run `mvn clean install`.
+A build profile is required for windows users who have to run `mvn clean install -Pwindows`.
 
 ## Running
 


### PR DESCRIPTION
This is a requirement when building in windows (I have also another issue with some tests that I need to bypass, but this is another topic and I have not determined the root cause, so cannot contribute it as is).